### PR TITLE
Update constant to use UnitOfTemperature

### DIFF
--- a/custom_components/mertik/sensor.py
+++ b/custom_components/mertik/sensor.py
@@ -2,7 +2,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from homeassistant.components.sensor import SensorEntity
 
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import UnitOfTemperature
 
 from .const import DOMAIN
 
@@ -40,4 +40,4 @@ class MertikAmbientTemperatureSensorEntity(CoordinatorEntity, SensorEntity):
     @property
     def unit_of_measurement(self) -> str:
         """Return the unit of measurement."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS


### PR DESCRIPTION
Fixing an error raised in the logs for this component:

`TEMP_CELSIUS was used from mertik, this is a deprecated constant which will be removed in HA Core 2025.1. Use UnitOfTemperature.CELSIUS instead, please report it to the author of the 'mertik' custom integration`